### PR TITLE
Update VPC name to pei-vpc

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,7 +10,7 @@ resource "aws_vpc" "main" {
   enable_dns_support   = true
 
   tags = {
-    Name = "${var.project_name}-vpc"
+    Name = "pei-vpc"
   }
 }
 


### PR DESCRIPTION
This PR updates the VPC name in the Terraform configuration from the dynamic `"${var.project_name}-vpc"` to the static name `"pei-vpc"`.

## Changes
- Updated the VPC resource name tag from `"${var.project_name}-vpc"` to `"pei-vpc"` in `terraform/main.tf`

## Impact
- The VPC will now be named "pei-vpc" instead of using the project name variable
- This provides a consistent, predictable name for the VPC resource

## Testing
- Please review the Terraform configuration to ensure the change is correct
- Run `terraform plan` to verify the expected changes before applying